### PR TITLE
Added accessibility labels to the headers and footers in the theme

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -64,7 +64,7 @@
 				</div><!-- span3 -->
 	
 	
-				<div class="span3">
+				<div class="span3 bc-footer">
                     <div id="bclogo">
                 	
                 	<p class="bc-service">91.3 KBCS is a public service at</p>

--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,7 @@
 						<li><a href="<?php echo home_url(); ?>/support/business/">Business Support</a></li>
                         <li><a href="<?php echo home_url(); ?>/donate/">Donate</a></li>
 						<li><a href="<?php echo home_url(); ?>/support/volunteer/">Volunteer</a></li>
-						<li><a href="<?php echo home_url(); ?>/support/">More...</a></li>
+						<li><a href="<?php echo home_url(); ?>/support/">More ways to support us</a></li>
 					</ul>
 					<h4>Legal</h4>
 					<ul>
@@ -68,7 +68,7 @@
                     <div id="bclogo">
                 	
                 	<p class="bc-service">91.3 KBCS is a public service at</p>
-                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" /></a></div> <!--bclogo-->
+                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College website" /></a></div> <!--bclogo-->
    
 				</div><!-- span3 -->
 			</div><!-- row -->

--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,7 @@
 						<li><a href="<?php echo home_url(); ?>/support/business/">Business Support</a></li>
                         <li><a href="<?php echo home_url(); ?>/donate/">Donate</a></li>
 						<li><a href="<?php echo home_url(); ?>/support/volunteer/">Volunteer</a></li>
-						<li><a href="<?php echo home_url(); ?>/support/">More ways to support us</a></li>
+						<li><a href="<?php echo home_url(); ?>/support/">Support Us</a></li>
 					</ul>
 					<h4>Legal</h4>
 					<ul>

--- a/header.php
+++ b/header.php
@@ -162,7 +162,7 @@
                                 
                                		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input class="span3" type="text" name="s" aria-label="Search" value="<?php echo trim( get_search_query() ); ?>">
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
                                          <input id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>

--- a/header.php
+++ b/header.php
@@ -150,7 +150,7 @@
 				<div class="row">
 					<div class="span2">					
 		                <div id="header-logo" class="hidden-phone">  
-							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><img src="<?php bloginfo('template_directory'); ?>/img/kbcs_logo.png" alt="91.3 KBCS"  title="KBCS home page" /></a>
+							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><img src="<?php bloginfo('template_directory'); ?>/img/kbcs_logo.png" alt="91.3 KBCS - Home Page"  title="KBCS home page" /></a>
 							
 						</div><!-- header-logo -->	
 					</div><!-- span2 -->

--- a/header.php
+++ b/header.php
@@ -126,7 +126,7 @@
 							/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 							wp_nav_menu( array( 
 								'menu' => 'main-nav', 
-								'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation">%3$s</ul>',
+								'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 								'container_class' => 'nav-collapse', 
 								'menu_class' => 'nav', 
 								'fallback_cb' => 'wp_page_menu',
@@ -181,7 +181,7 @@
 												/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 												wp_nav_menu( array( 
 													'menu' => 'main-nav', 
-													'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation">%3$s</ul>',
+													'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 													'container_class' => 'nav-collapse', 
 													'menu_class' => 'nav', 
 													'fallback_cb' => 'wp_page_menu',
@@ -203,7 +203,7 @@
 		</div><!-- row -->
 
 
-		<div id="enable_javascript">Please enable your javascript to have a better view of the website. Click <a href="http://activatejavascript.org" target="_blank">here</a> to learn more about it.</div>
+		<div id="enable_javascript">Please enable your javascript to have a better view of the website. Learn about <a href="http://activatejavascript.org" target="_blank">activating javascript here.</a></div>
 
 
 

--- a/header.php
+++ b/header.php
@@ -162,9 +162,9 @@
                                 
                                		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input class="span3" type="text" name="s" aria-label="Search" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input role="search" class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-                                         <input id="searchsubmit" value="Search" type="submit" class="btn" />
+                                         <input role="button" id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>
 
                                 

--- a/header.php
+++ b/header.php
@@ -126,7 +126,7 @@
 							/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 							wp_nav_menu( array( 
 								'menu' => 'main-nav', 
-								'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
+								'items_wrap'      => '<nav aria-labelledby="main-nav"><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 								'container_class' => 'nav-collapse', 
 								'menu_class' => 'nav', 
 								'fallback_cb' => 'wp_page_menu',
@@ -181,7 +181,7 @@
 												/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 												wp_nav_menu( array( 
 													'menu' => 'main-nav', 
-													'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
+													'items_wrap'      => '<nav aria-labelledby="main-nav"><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 													'container_class' => 'nav-collapse', 
 													'menu_class' => 'nav', 
 													'fallback_cb' => 'wp_page_menu',

--- a/header.php
+++ b/header.php
@@ -160,11 +160,11 @@
 							<div class="span10">
 							    <div class="input-append pull-right global-search hidden-phone">
                                 
-                               		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
+                               		 <form role="search" id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input role="search" class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-                                         <input role="button" id="searchsubmit" value="Search" type="submit" class="btn" />
+                                         <input id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>
 
                                 

--- a/searchform.php
+++ b/searchform.php
@@ -1,8 +1,8 @@
 <form id="search" class="" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
   <div class="input-append">
 		<span aria-hidden="true" data-icon="&#xf002;"></span>
-		<input class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+		<input label="Search" class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 		<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-		<button id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
+		<button label="button" id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
   </div>
 </form>

--- a/searchform.php
+++ b/searchform.php
@@ -1,8 +1,8 @@
 <form id="search" class="" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
   <div class="input-append">
 		<span aria-hidden="true" data-icon="&#xf002;"></span>
-		<input label="Search" class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+		<input class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 		<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-		<button label="button" id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
+		<button id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
   </div>
 </form>

--- a/style.css
+++ b/style.css
@@ -1144,6 +1144,10 @@ div.span6 a {
 		margin-top: 5px;
 	}
 	#hero-links { margin-top: 10px;}
+
+	#bclogo { 
+		margin-left: 0px;
+	}
 }
 
 /* Landscape phone to portrait tablet */
@@ -1291,6 +1295,9 @@ div.span6 a {
 		padding: 5px 20px;
 	}
 	
+	#bclogo { 
+		margin-left: 0px;
+	}
 
 }
  
@@ -1364,6 +1371,10 @@ div.span6 a {
 	
 	margin: 0;
 	padding: 5px 0px;
+	}
+
+	#bclogo { 
+		margin-left: 0px;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -571,11 +571,23 @@ img.alignright {
 .media-content p:first-child {
 	margin-top: 0;
 }	
+
 /*Footer*/
 #foot {
 	border-top: 1px dashed #ddd;
 	margin-top: 80px;
 	padding-bottom:200px;
+}
+
+#foot .bc-service {
+	font-size: 16px;
+	padding-left: 38px;
+}
+
+#foot #bclogo { 
+	margin-left: -100px;
+    padding-top: 15px;
+    text-align: center;
 }
 
 #foot h4 {
@@ -596,20 +608,12 @@ img.alignright {
 #foot a:hover, #foot a:focus {
 	color: #003d79;
 	}
-.bc-service {
-	font-size: 12px;
-	padding-left: 38px;
-}
-#bclogo { 
-	margin-left: -100px;
-    padding-top: 15px;
-    text-align: center;}
 #foot .row2 {
 	margin-top: 70px;
     padding-bottom: 30px;
 }
 
-.span3 ul li, .bc-service {
+.span3 ul li, .bc-service, .vcard {
 	font-size: 16px;
 	margin-bottom: 8px;
 }
@@ -1162,8 +1166,18 @@ div.span6 a {
 	}
 	#hero-links { margin-top: 10px;}
 
-	#bclogo { 
+	#foot .span3{
 		margin-left: 0px;
+		/* Override bootstrap width */
+		width: 200px;
+	}
+
+	#foot .span3 #bclogo { 
+		margin-left: -20px;
+	}
+
+	#foot .bc-footer {
+		width: 140px;
 	}
 
 	/* Donate page styling for buttons */

--- a/style.css
+++ b/style.css
@@ -1132,7 +1132,34 @@ div.span6 a {
 
 /* Portrait tablet to landscape and desktop */
 @media (min-width: 768px) and (max-width: 979px) {
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
+	}
+
+	/* Footer styling */
+	#foot .span3{
+		margin-left: 0px;
+		/* Override bootstrap width */
+		width: 200px;
+	}
+
+	#foot .span3 #bclogo { 
+		margin-left: -20px;
+	}
+
+	#foot .bc-footer {
+		width: 140px;
+	}
 	
+	/* Misc */
 	#main-nav.nav > li > a {
 	  font-size: 14px;
 	  line-height:22px;
@@ -1165,31 +1192,6 @@ div.span6 a {
 		margin-top: 5px;
 	}
 	#hero-links { margin-top: 10px;}
-
-	#foot .span3{
-		margin-left: 0px;
-		/* Override bootstrap width */
-		width: 200px;
-	}
-
-	#foot .span3 #bclogo { 
-		margin-left: -20px;
-	}
-
-	#foot .bc-footer {
-		width: 140px;
-	}
-
-	/* Donate page styling for buttons */
-	.donateButton a {
-		font-size: 24px;
-		border-radius: 14px;
-		
-	}
-
-	.donateButtonSpacer {
-		flex-basis: 0px!important;
-	}
 }
 
 /* Landscape phone to portrait tablet */

--- a/style.css
+++ b/style.css
@@ -580,7 +580,7 @@ img.alignright {
 
 #foot h4 {
  	font-family: 'PT Sans',"Helvetica Neue",Helvetica,Arial,sans-serif;
-	font-size: 16px;
+	font-size: 20px;
 	font-weight: bold;
 	color: #333;
 	}
@@ -607,6 +607,11 @@ img.alignright {
 #foot .row2 {
 	margin-top: 70px;
     padding-bottom: 30px;
+}
+
+.span3 ul li, .bc-service {
+	font-size: 16px;
+	margin-bottom: 8px;
 }
 	
 /*funddrive box*/

--- a/style.css
+++ b/style.css
@@ -1068,6 +1068,12 @@ div.span6 a {
     word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
+/* Donate Page */
+.donateButton a {
+	font-size: 20px;
+	border-radius: 14px;
+}
+
 /* Large desktop overides */
 @media (min-width: 1200px) {
 	.blog h2, .home h2 {
@@ -1105,6 +1111,12 @@ div.span6 a {
 
 	#error404-goodnews h1 {
 		padding-top: 90px;
+	}
+
+	/* Donate Page, styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
 	}
 	
 }
@@ -1147,6 +1159,17 @@ div.span6 a {
 
 	#bclogo { 
 		margin-left: 0px;
+	}
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
 	}
 }
 
@@ -1297,6 +1320,17 @@ div.span6 a {
 	
 	#bclogo { 
 		margin-left: 0px;
+	}
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
 	}
 
 }


### PR DESCRIPTION
This change adds labels to content that might want to be skimmed by a screen reader. 

### In the header

- The nav bar now has a nav tag.
- The search field is now labeled as a search object
- The search button is now labeled as a button

These fixes will benefit screen reader users by allowing them to semantically navigate the header and get feedback about what element they are interacting with.

### In the footer

- The link to the support page with the text "more..." is now labeled "Support Us", allowing screen readers to understand where this link goes.
- The font sizes have been increased to allow for larger touch targets. This supports people with mobility issues to be able to click on the intended link.

### CSS changes

- Reflowed my styles to be more specific
- Put styles in appropriate places in alphabetical order
- Added comments to my styles to make them easy to find.

Overall, these changes are a good start at making the website more accessible.