### PR TITLE
Fix catlist template

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 <div class="row">
-	<div class="span8" id="content">
+	<main class="span8" id="content">
         	<div class="row">
             	<div class="span4">
                 	<div id="error404-goodnews">
@@ -29,7 +29,7 @@
                 <li> if you typed the web address, make sure you typed it correctly</li>
             </ul>
 			</div>
-	</div><!-- #content span8 -->
+	</main><!-- #content span8 -->
 	<?php get_sidebar(); ?>
 </div><!-- row -->
 

--- a/footer.php
+++ b/footer.php
@@ -64,7 +64,7 @@
 				</div><!-- span3 -->
 	
 	
-				<div class="span3">
+				<div class="span3 bc-footer">
                     <div id="bclogo">
                 	
                 	<p class="bc-service">91.3 KBCS is a public service at</p>

--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,7 @@
 						<li><a href="<?php echo home_url(); ?>/support/business/">Business Support</a></li>
                         <li><a href="<?php echo home_url(); ?>/donate/">Donate</a></li>
 						<li><a href="<?php echo home_url(); ?>/support/volunteer/">Volunteer</a></li>
-						<li><a href="<?php echo home_url(); ?>/support/">More...</a></li>
+						<li><a href="<?php echo home_url(); ?>/support/">More ways to support us</a></li>
 					</ul>
 					<h4>Legal</h4>
 					<ul>
@@ -68,7 +68,7 @@
                     <div id="bclogo">
                 	
                 	<p class="bc-service">91.3 KBCS is a public service at</p>
-                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" /></a></div> <!--bclogo-->
+                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College website" /></a></div> <!--bclogo-->
    
 				</div><!-- span3 -->
 			</div><!-- row -->

--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,7 @@
 						<li><a href="<?php echo home_url(); ?>/support/business/">Business Support</a></li>
                         <li><a href="<?php echo home_url(); ?>/donate/">Donate</a></li>
 						<li><a href="<?php echo home_url(); ?>/support/volunteer/">Volunteer</a></li>
-						<li><a href="<?php echo home_url(); ?>/support/">More ways to support us</a></li>
+						<li><a href="<?php echo home_url(); ?>/support/">Support Us</a></li>
 					</ul>
 					<h4>Legal</h4>
 					<ul>

--- a/footer.php
+++ b/footer.php
@@ -2,29 +2,27 @@
 		</div><!-- container footer-widgets -->
 </div><!-- wrapper container -->
 
-		<div class="container" id="foot">
+		<footer class="container" id="foot">
 			<div class="row">
 
-				<div class="span3">
+				<nav class="span3">
                 	
                      <div class="vcard">
                          <div class="org"><h4><a class="url fn n" href="<?php echo home_url(); ?>/">KBCS Radio</a></h4></div>
                          
-                         <div class="adr">
-                              <div class="street-address">3000 Landerholm Circle SE</div>
-                              <span class="locality">Bellevue</span>,
-                              <span class="region">WA</span>
-                              <span class="postal-code">98007-6406</span>
-                         </div>
+                         <address class="adr">
+                              <p class="street-address">3000 Landerholm Circle SE</p>
+							  <p class="street-address">Bellevue, WA 98007-6406</p>
+                         </address>
                      
                      	<ul>    
                             <li><a href="<?php echo home_url(); ?>/about/contact/"><strong>Contact Us</strong></a></li>
                             <li><a href="<?php echo home_url(); ?>/about/directions/"><strong>Map &amp; directions</strong></a></li>
                         </ul>
                    </div><!-- .vcard -->
-				</div><!-- span3 -->
+				</nav><!-- span3 -->
                 
-                <div class="span3">
+                <nav class="span3">
 					
                     <h4>Music Requests</h4>
                     <ul>
@@ -44,10 +42,10 @@
 					<li><a href="mailto:dj@kbcs.fm">news@kbcs.fm</a></li>
 					<li>425-564-6195</li>
 					</ul>
-				</div><!-- span3 -->
+				</nav><!-- span3 -->
 	
 	
-				<div class="span3">
+				<nav class="span3">
 					<h4>Connect</h4>
 					<ul>
 						<li><a href="<?php echo home_url(); ?>/support/business/">Business Support</a></li>
@@ -61,19 +59,19 @@
 						<li><a href="https://www.bellevuecollege.edu/trustees/">Controlling Board of KBCS</a></li>
 						<li><a href="https://www.bellevuecollege.edu/events/trustees/">Board Meetings</a></li>
 					</ul>
-				</div><!-- span3 -->
+				</nav><!-- span3 -->
 	
 	
-				<div class="span3 bc-footer">
+				<nav class="span3 bc-footer">
                     <div id="bclogo">
                 	
                 	<p class="bc-service">91.3 KBCS is a public service at</p>
-                    <a href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College website" /></a></div> <!--bclogo-->
+                    <a role="button" href="https://www.bellevuecollege.edu"><img src="<?php bloginfo('stylesheet_directory'); ?>/img/bellevuecollege.png" alt="Bellevue College" /></a></div> <!--bclogo-->
    
-				</div><!-- span3 -->
+				</nav><!-- span3 -->
 			</div><!-- row -->
 		
-		</div><!-- footer .container -->
+		</footer><!-- footer .container -->
 
 <?php wp_footer(); ?>
 

--- a/format-standard.php
+++ b/format-standard.php
@@ -1,6 +1,7 @@
+<article>
 <h2 <?php post_class() ?>><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 <div class="media">
-	<a class="pull-left" href="<?php the_permalink(); ?>">
+	<div class="media-left">
 		<?php
 		if ( has_post_thumbnail() ) {
 			the_post_thumbnail( 'thumbnail', array( 'class' => 'media-object' ) );
@@ -11,9 +12,8 @@
 			}
 		}
 		?>
-	</a>
-	<div class="media-body">
-		<div class="media-content">
+	</div>
+		<section class="media-content">
 			<p><small><?php the_time( 'F j, Y' ); ?> - <?php the_time( 'g:i a' ); ?></small></p>
 			<?php
 			if ( @strpos( $post->post_content, '<!--more-->') ) {
@@ -26,6 +26,6 @@
 				the_excerpt();
 			}
 			?>
-		</div>
-	</div>
+		</section>
 </div>
+</article>

--- a/format-video.php
+++ b/format-video.php
@@ -1,3 +1,4 @@
+<article>
 <h2 <?php post_class() ?>>							
 	<a href="<?php the_permalink(); ?>"><?php the_title();?></a>
 </h2>
@@ -7,3 +8,4 @@
 <div class="video-container">
 	<?php the_content(); ?>
 </div>
+</article>

--- a/front-page.php
+++ b/front-page.php
@@ -4,62 +4,63 @@ get_header();
 <div class="whatpageisthis">front-page.php</div>
 <div class="container">
 	<div class="row">
-		<div class="span8" id="content">
-		<div id="hero-onair">On air</div>
-			<div id="hero-block" class="loading">
-				<div class="row-fluid" id="hero-text-wrapper">
-					<div class="loading">Loading...</div>
-					<div class="span9" id="hero-text">
-						<div class="inner">
-							<h1 id="hero-title"></h1>
-							<p id="hero-host" class="hostedby"></p>
-							<p id="hero-airtimes" class="program-days-times"></p>
-							<ul id="hero-links">
-								<li>
-									<a href="https://www.radiorethink.com/tuner/?stationCode=kbcs&stream=hi" class="streamlive" onClick="gaplusu('send', 'event', 'Outbound', 'Homepage Jumbotron', 'Live Stream');">
-										<i class="icon-volume-up"></i>Listen live
-									</a>
-								</li>
-								<li>
-									<a href="<?php echo home_url(); ?>/live-playlist/">
-										<i class="icon-th-list"></i>View Playlist
-									</a>
-								</li>
-								<li>
-									<a id="hero-link" href="" title="">
-										<i class="icon-list-alt"></i>View Program page
-									</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-				</div>
-				<div id="hero-image">
-					<img src="<?php echo get_stylesheet_directory_uri(); ?>/img/program-hero-generic.jpg" alt="photo of cds in KBCS library" />
-				</div>
-			</div>
-			<ul id="hero-past-future" class="loading">
-				<li id="hero-past">
-					<a id="hero-past-link" href="">
-						<span class="inner">
-							<em><span class="corner"></span>Last Show</em>
-							<span id="hero-past-time"></span>
-							<span id="hero-past-title"></span>
-						</span>
-					</a>
-				</li>
-				<li id="hero-future">
-					<a id="hero-future-link" href="">
-						<span class="inner">
-							<em><span class="corner"></span>Next Show</em>
-							<span id="hero-future-time"></span>
-							<span id="hero-future-title"></span>
-						</span>
-					</a>
-				</li>
-			</ul>
-			<p id="schedulelink"><a href="program/"><i class="icon-calendar"></i>Weekly Schedule</a></p>
-
+		<main class="span8" id="content">
+			<section label="On-Air">
+				<div id="hero-onair">On air</div>
+					<div id="hero-block" class="loading">
+						<div class="row-fluid" id="hero-text-wrapper">
+							<div class="loading">Loading...</div>
+							<div class="span9" id="hero-text">
+								<div class="inner">
+									<h1 id="hero-title"></h1>
+									<p id="hero-host" class="hostedby"></p>
+									<p id="hero-airtimes" class="program-days-times"></p>
+									<ul id="hero-links">
+										<li>
+											<a href="https://www.radiorethink.com/tuner/?stationCode=kbcs&stream=hi" class="streamlive" onClick="gaplusu('send', 'event', 'Outbound', 'Homepage Jumbotron', 'Live Stream');">
+												<i class="icon-volume-up"></i>Listen live
+											</a>
+										</li>
+										<li>
+											<a href="<?php echo home_url(); ?>/live-playlist/">
+												<i class="icon-th-list"></i>View Playlist
+											</a>
+										</li>
+										<li>
+											<a id="hero-link" href="" title="">
+												<i class="icon-list-alt"></i>View Program page
+											</a>
+										</li>
+									</ul>
+								</div> <!-- inner -->
+							</div> <!-- hero-text -->
+						</div> <!-- row-fluid -->
+						<div id="hero-image">
+							<img src="<?php echo get_stylesheet_directory_uri(); ?>/img/program-hero-generic.jpg" alt="photo of cds in KBCS library" />
+						</div> <!-- hero-image -->
+					</div> <!-- hero-block -->
+					<ul id="hero-past-future" class="loading">
+						<li id="hero-past">
+							<a id="hero-past-link" href="">
+								<span class="inner">
+									<em><span class="corner"></span>Last Show</em>
+									<span id="hero-past-time"></span>
+									<span id="hero-past-title"></span>
+								</span>
+							</a>
+						</li>
+						<li id="hero-future">
+							<a id="hero-future-link" href="">
+								<span class="inner">
+									<em><span class="corner"></span>Next Show</em>
+									<span id="hero-future-time"></span>
+									<span id="hero-future-title"></span>
+								</span>
+							</a>
+						</li>
+					</ul>
+					<p id="schedulelink"><a href="program/"><i class="icon-calendar"></i>Weekly Schedule</a></p>
+			</section> <!-- On-Air -->
 			<?php
 			$sticky = get_option( 'sticky_posts' );
 			$args = array(
@@ -76,8 +77,8 @@ get_header();
 
 			if ( $sticky ) {
 			?>
-			<h2 <?php post_class() ?>><a href="<?php the_permalink(); ?>"><?php the_title();?></a></h2>
-			<div class="media">
+			<article class="media"> <!-- TODO : Make this tag appear in rendered page -->
+				<h2 <?php post_class() ?>><a href="<?php the_permalink(); ?>"><?php the_title();?></a></h2>
 				<a class="pull-left" href="<?php the_permalink(); ?>">
 				<?php
 					if ( has_post_thumbnail() ) {
@@ -91,7 +92,7 @@ get_header();
 					<div class="media-content">
 						<p><small><?php the_time( 'F j, Y' ); ?> - <?php the_time( 'g:i a' ); ?></small></p>
 						<?php the_excerpt(); ?>
-					</div>
+					</div> <!-- media-content -->
 					<?php if ( ! is_single( $post ) ) { ?>
 					<p>
 						<a class="btn btn-small primary-read-more" href="<?php the_permalink(); ?>">
@@ -99,8 +100,9 @@ get_header();
 						</a>
 					</p>
 					<?php } ?>
-				</div>
-			</div>
+				</div> <!-- media-body -->
+			</article> <!-- media -->
+			
 			<?php
 			}
 			endwhile;
@@ -128,10 +130,10 @@ get_header();
 			endwhile;
 			wp_reset_postdata();
 			?>
-		</div>
+		</main> <!-- content -->
 		<?php get_sidebar(); ?>
-	</div>
-</div>
+	</div> <!-- row -->
+</div> <!-- container -->
 <script type="text/javascript">
 	jQuery(function() { jQuery("#hero-past-future .title").equalHeights(); });
 </script>

--- a/header.php
+++ b/header.php
@@ -162,7 +162,7 @@
                                 
                                		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input class="span3" type="text" name="s" aria-label="Search" value="<?php echo trim( get_search_query() ); ?>">
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
                                          <input id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>

--- a/header.php
+++ b/header.php
@@ -150,7 +150,7 @@
 				<div class="row">
 					<div class="span2">					
 		                <div id="header-logo" class="hidden-phone">  
-							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><img src="<?php bloginfo('template_directory'); ?>/img/kbcs_logo.png" alt="91.3 KBCS"  title="KBCS home page" /></a>
+							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><img src="<?php bloginfo('template_directory'); ?>/img/kbcs_logo.png" alt="91.3 KBCS - Home Page"  title="KBCS home page" /></a>
 							
 						</div><!-- header-logo -->	
 					</div><!-- span2 -->

--- a/header.php
+++ b/header.php
@@ -126,7 +126,7 @@
 							/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 							wp_nav_menu( array( 
 								'menu' => 'main-nav', 
-								'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation">%3$s</ul>',
+								'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 								'container_class' => 'nav-collapse', 
 								'menu_class' => 'nav', 
 								'fallback_cb' => 'wp_page_menu',
@@ -181,7 +181,7 @@
 												/** Loading WordPress Custom Menu with Fallback to wp_list_pages **/
 												wp_nav_menu( array( 
 													'menu' => 'main-nav', 
-													'items_wrap'      => '<ul id="%1$s" class="%2$s" role="navigation">%3$s</ul>',
+													'items_wrap'      => '<nav><ul id="%1$s" class="%2$s" role="navigation">%3$s</ul></nav>',
 													'container_class' => 'nav-collapse', 
 													'menu_class' => 'nav', 
 													'fallback_cb' => 'wp_page_menu',
@@ -203,7 +203,7 @@
 		</div><!-- row -->
 
 
-		<div id="enable_javascript">Please enable your javascript to have a better view of the website. Click <a href="http://activatejavascript.org" target="_blank">here</a> to learn more about it.</div>
+		<div id="enable_javascript">Please enable your javascript to have a better view of the website. Learn about <a href="http://activatejavascript.org" target="_blank">activating javascript here.</a></div>
 
 
 

--- a/header.php
+++ b/header.php
@@ -112,7 +112,7 @@
 ?>
 
 	<!-- Phone/Tablet Nav Menu -->
-		<div class="row visible-phone">
+		<header class="row visible-phone">
 			<div class="navbar top-mobile-nav">
 				<div class="navbar-inner">
                 	<div class="container">
@@ -137,7 +137,7 @@
                        </div><!--container-->
 				</div><!-- navbar-inner -->
 			</div><!-- navbar -->
-		</div><!-- row -->
+		</header><!-- row -->
 
 	<!-- Show Now Playing, Live Stream & Playlists/Audio Archives on small screens -->
 		<div class="nowplaying visible-phone">
@@ -145,7 +145,7 @@
 	    </div> <!--#nowplaying-->
 
 	
-		<div class="row site-header">
+		<header class="row site-header">
 			<div class="span12">
 				<div class="row">
 					<div class="span2">					
@@ -162,7 +162,7 @@
                                 
                                		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input role="search" class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input role="search" class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>"/>
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
                                          <input role="button" id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>
@@ -192,7 +192,7 @@
                                             	<span aria-hidden="true" data-icon="&#xf0c9;"></span>
                                        			Menu
                                             </a>
-                                           </div><!--container-->
+                                        </div><!--container-->
 									</div><!-- navbar-inner -->
 								</div><!-- navbar -->
 					    	</div><!-- span10 -->
@@ -200,7 +200,7 @@
 					</div><!-- span10 -->
 				</div><!-- row -->		
 			</div><!-- span12 -->
-		</div><!-- row -->
+		</header><!-- row -->
 
 
 		<div id="enable_javascript">Please enable your javascript to have a better view of the website. Learn about <a href="http://activatejavascript.org" target="_blank">activating javascript here.</a></div>

--- a/header.php
+++ b/header.php
@@ -162,9 +162,9 @@
                                 
                                		 <form id="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
                                         <span aria-hidden="true" data-icon="&#xf002;"></span>
-                                        <input class="span3" type="text" name="s" aria-label="Search" value="<?php echo trim( get_search_query() ); ?>">
+                                        <input role="search" class="span3" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 										<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-                                         <input id="searchsubmit" value="Search" type="submit" class="btn" />
+                                         <input role="button" id="searchsubmit" value="Search" type="submit" class="btn" />
 							    	</form>
 
                                 

--- a/home.php
+++ b/home.php
@@ -4,7 +4,7 @@
 	<!-- <div id="enable_javascript">Please enable your javascript to have a better view of the website. Click <a href="http://activatejavascript.org">here</a> to learn more about it.</div> -->
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content">
 
 				<?php
 					$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
@@ -34,7 +34,7 @@
 									     
 					?>
 					    
-    		</div><!--#content .span8 -->
+    		</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content"> <!-- Why is this not showing up in the DOM on my browser? -->
 
 
 		<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
@@ -15,7 +15,7 @@
 		<?php endif; ?>
 	
     
-    		</div><!--#content .span8 -->
+    		</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/list-category-posts/single-blog.php
+++ b/list-category-posts/single-blog.php
@@ -1,0 +1,35 @@
+<?php get_header(); ?>
+
+<div class="whatpageisthis">single-blog.php</div>		
+
+	<div class="container">
+        <div class="row">	
+            <div class="span8" id="content">
+
+
+		<?php 
+			$query = new WP_Query( array(
+                'post_type' => 'blog',
+                'category_name' => 'news-and-ideas'
+            ) ); 
+		?>
+		<?php 
+		if ( have_posts() ) : while ( have_posts() ) : the_post(); 
+
+		if(!get_post_format()) {
+				               get_template_part('format', 'standard');
+			         } else {
+				               get_template_part('format', get_post_format());
+				          }
+
+					endwhile;
+					posts_nav_link();
+					wp_reset_query();
+					endif; ?>
+
+
+			</div><!--#content .span8 -->
+			<?php get_sidebar(); ?>
+		</div><!-- row -->
+	</div><!-- container -->
+<?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -2,7 +2,7 @@
 <div class="whatpageisthis">page.php</div>
 
 <div class="row">
-	<div class="span8" id="content">
+	<main class="span8" id="content">
 		<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 		
         <h1><?php the_title();?></h1>
@@ -11,7 +11,7 @@
 		<?php endwhile; else: ?>
 		<p><?php _e('Sorry, no posts matched your criteria.'); ?></p>
 		<?php endif; ?>
-	</div><!-- span8  #content -->
+	</main><!-- span8  #content -->
     
 	<?php get_sidebar(); // sidebar 1 ?>
 

--- a/search.php
+++ b/search.php
@@ -10,7 +10,7 @@ get_header(); ?>
 
 <div class="whatpageisthis">search.php</div>
 <div class="row">
-	<div class="span8" id="content">
+	<main class="span8" id="content">
 		<h1 class="search-page-title">
 			<?php
 			/* Search Count */
@@ -103,7 +103,7 @@ get_header(); ?>
 			}
 	?>
 		</div>
-	</div><!-- span8 #content -->
+	</main><!-- span8 #content -->
 	<?php get_sidebar(); // sidebar 1 ?>
 
 </div><!-- row -->

--- a/searchform.php
+++ b/searchform.php
@@ -1,7 +1,7 @@
 <form id="search" class="" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
   <div class="input-append">
 		<span aria-hidden="true" data-icon="&#xf002;"></span>
-		<input label="Search" class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+		<input role="search" label="Search" class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>"/>
 		<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
 		<button label="button" id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
   </div>

--- a/searchform.php
+++ b/searchform.php
@@ -1,8 +1,8 @@
 <form id="search" class="" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>"> 
   <div class="input-append">
 		<span aria-hidden="true" data-icon="&#xf002;"></span>
-		<input class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
+		<input label="Search" class="input-xlarge" type="text" name="s" value="<?php echo trim( get_search_query() ); ?>">
 		<input type='hidden' name='post_type' value='programs,segments,staff,events,ads' />
-		<button id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
+		<button label="button" id="searchsubmit" value="Search" type="submit" class="btn">Search</button>
   </div>
 </form>

--- a/sidebar.php
+++ b/sidebar.php
@@ -27,13 +27,13 @@
 	</div>
 
 	<div id="social-links">
-		<div>
+		<div role ="button">
 			<a class="btn btn-primary btn-block" href="https://www.facebook.com/KBCSBellevueSeattle"><i class="icon-facebook"></i> Facebook</a>
 		</div>
-		<div>
+		<div role="button">
 			<a class="btn btn-info btn-block" href="https://twitter.com/KBCS"><i class="icon-twitter"></i> Twitter</a>
 		</div>
-		<div>
+		<div role="button">
 			<a class="btn btn-default btn-block" href="https://bellevuecollegefoundation.thankyou4caring.org/kbcs/email_communication">Newsletter</a>
 		</div>
 	</div>
@@ -49,7 +49,7 @@
 	$query = new WP_Query( $args );
 
 	while ( $query->have_posts() ) : $query->the_post(); ?>
-		<div id="ad-manager">
+		<div role= id="ad-manager">
 			<a href="<?php echo get_post_meta(get_the_id(), '_links_to', true);?>">
 				<?php echo the_post_thumbnail("sidebar-ad"); ?>
 			</a>

--- a/sidebar.php
+++ b/sidebar.php
@@ -26,7 +26,7 @@
 		<iframe src="//widgets.spinitron.com/widget/now-playing-v2?station=kbcs&num=5&sharing=1&cover=1&player=1&merch=0&non-music=1" width="100%" frameborder="0" allow="encrypted-media"></iframe>
 	</div>
 
-	<div id="social-links">
+	<nav id="social-links">
 		<div role ="button">
 			<a class="btn btn-primary btn-block" href="https://www.facebook.com/KBCSBellevueSeattle"><i class="icon-facebook"></i> Facebook</a>
 		</div>
@@ -36,7 +36,7 @@
 		<div role="button">
 			<a class="btn btn-default btn-block" href="https://bellevuecollegefoundation.thankyou4caring.org/kbcs/email_communication">Newsletter</a>
 		</div>
-	</div>
+	</nav>
 	<?php
 	$args = array(
 		'post_type' => 'ads',
@@ -49,7 +49,7 @@
 	$query = new WP_Query( $args );
 
 	while ( $query->have_posts() ) : $query->the_post(); ?>
-		<div role= id="ad-manager">
+		<div id="ad-manager">
 			<a href="<?php echo get_post_meta(get_the_id(), '_links_to', true);?>">
 				<?php echo the_post_thumbnail("sidebar-ad"); ?>
 			</a>

--- a/sidebar.php
+++ b/sidebar.php
@@ -2,7 +2,7 @@
 ### Sidebar - Contains Sub Page navigation
 ### Automatically appears if sub-nav exists
 ?>
-<div class="sidebar span4">
+<aside class="sidebar span4">
 	<div class="navbar sidebar-audio-buttons hidden-phone">
 		<div class="navbar-inner">
 			<div class="container">
@@ -61,4 +61,4 @@
 	<?php dynamic_sidebar( 'Events Widget Area' ); ?>
 
 	<?php dynamic_sidebar( 'Sidebar Bottom' ); ?>
-</div><!-- sidebar span4 -->
+</aside><!-- sidebar span4 -->

--- a/single-audio.php
+++ b/single-audio.php
@@ -4,14 +4,14 @@
 
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content">
 
 				<?php while (have_posts() ) : the_post(); ?>
 					<h2><?php the_title(); ?></h2>
 					<?php the_content(); ?>		
 				<?php endwhile; ?>
 
-			</div><!--#content .span8 -->
+			</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/single-blog.php
+++ b/single-blog.php
@@ -4,7 +4,7 @@
 
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content">
 
 
 		<?php $query = new WP_Query( 'post_type=blog' ); ?>
@@ -16,7 +16,7 @@
 		<?php endif; ?>
 
 
-			</div><!--#content .span8 -->
+			</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/single-episodes.php
+++ b/single-episodes.php
@@ -15,7 +15,7 @@ single-programs
 
 		<div class="container">
 			<div class="row content">					
-				<div class="span8 single-news">
+				<main class="span8 single-news">
 
 					<div class="content-padding-left-right-extra">
 	 					<h1><?php the_title();?></h1>
@@ -59,7 +59,7 @@ single-programs
 	
 						<hr />
 					</div><!-- content-padding -->
-				</div><!-- /.span8 -->
+				</main><!-- /.span8 -->
 				
 				<?php get_sidebar(); ?>
       	

--- a/single-mc-events.php
+++ b/single-mc-events.php
@@ -4,7 +4,7 @@
 
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content">
 				<?php
 				
 				if (have_posts()) : while (have_posts()) : the_post();
@@ -45,7 +45,7 @@ if ( has_post_format( 'quote' )) {
 
 				<?php wp_reset_query(); endif; ?>
 
-    		</div><!--#content .span8 -->
+    		</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/single-programs.php
+++ b/single-programs.php
@@ -63,7 +63,7 @@ $audio_content = json_encode($output);
 
 <div class="container">
 		<div class="row">
-			<div class="span8" id="content">
+			<main class="span8" id="content">
 			<div id="hero-block">
 
 				<div class="row-fluid"  id="hero-text-wrapper">
@@ -180,7 +180,7 @@ $audio_content = json_encode($output);
 </div>  <!--#jp_container_template-->   
 <!--End Templates-->     
 					
-			</div><!-- #content span8 -->
+			</main><!-- #content span8 -->
 			<?php get_sidebar(); // sidebar 1 ?>
 		</div><!-- row -->
 </div><!-- container -->  

--- a/single-segments.php
+++ b/single-segments.php
@@ -8,7 +8,7 @@ get_header(); ?>
 
 <div class="container">
 		<div class="row">
-			<div class="span8" id="content">
+			<main class="span8" id="content">
             <?php while ( have_posts() ) : the_post(); ?>
             <h1><?php the_title();?></h1>
             
@@ -45,7 +45,7 @@ get_header(); ?>
 							
 
 					
-			</div><!-- #content span8 -->
+			</main><!-- #content span8 -->
 	        <?php get_sidebar(); // sidebar 1 ?>
     	</div><!-- row -->
 </div><!-- container -->  

--- a/single-staff.php
+++ b/single-staff.php
@@ -8,7 +8,7 @@ get_header(); ?>
 
 <div class="container">
 		<div class="row">
-			<div class="span8" id="content">
+			<main class="span8" id="content">
             <?php while ( have_posts() ) : the_post(); ?>
             <h1><?php the_title();?></h1>
 
@@ -56,7 +56,7 @@ get_header(); ?>
 							
 
 					
-			</div><!-- #content span8 -->
+			</main><!-- #content span8 -->
 	        <?php get_sidebar(); // sidebar 1 ?>
     	</div><!-- row -->
 </div><!-- container -->  

--- a/single.php
+++ b/single.php
@@ -4,7 +4,7 @@
 
 	<div class="container">
         <div class="row">	
-            <div class="span8" id="content">
+            <main class="span8" id="content">
 				<?php
 				
 				if (have_posts()) : while (have_posts()) : the_post();
@@ -92,7 +92,7 @@ if ( has_post_format( 'quote' )) {
 
 				<?php wp_reset_query(); endif; ?>
 
-    		</div><!--#content .span8 -->
+    		</main><!--#content .span8 -->
 			<?php get_sidebar(); ?>
 		</div><!-- row -->
 	</div><!-- container -->

--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ div.aligncenter {
     margin: 5px auto 5px auto;
 }
 
-.alignright {
+.alignright, article .media-content {
     float:right;
     margin: 5px 0 20px 20px;
 }
@@ -65,7 +65,7 @@ a img.alignnone {
     margin: 5px 20px 20px 0;
 }
 
-a img.alignleft {
+a img.alignleft, img.media-object {
     float: left;
     margin: 5px 20px 20px 0;
 }
@@ -216,6 +216,14 @@ li { margin-top: 5px}
      -moz-border-radius: 5px;
           border-radius: 5px;
 	text-decoration: none;
+}
+
+.media {
+	display: flex;
+}
+
+.media-left {
+	width: 400px;
 }
 
 a.btn { text-decoration:none;}

--- a/style.css
+++ b/style.css
@@ -1144,6 +1144,10 @@ div.span6 a {
 		margin-top: 5px;
 	}
 	#hero-links { margin-top: 10px;}
+
+	#bclogo { 
+		margin-left: 0px;
+	}
 }
 
 /* Landscape phone to portrait tablet */
@@ -1291,6 +1295,9 @@ div.span6 a {
 		padding: 5px 20px;
 	}
 	
+	#bclogo { 
+		margin-left: 0px;
+	}
 
 }
  
@@ -1364,6 +1371,10 @@ div.span6 a {
 	
 	margin: 0;
 	padding: 5px 0px;
+	}
+
+	#bclogo { 
+		margin-left: 0px;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -571,11 +571,23 @@ img.alignright {
 .media-content p:first-child {
 	margin-top: 0;
 }	
+
 /*Footer*/
 #foot {
 	border-top: 1px dashed #ddd;
 	margin-top: 80px;
 	padding-bottom:200px;
+}
+
+#foot .bc-service {
+	font-size: 16px;
+	padding-left: 38px;
+}
+
+#foot #bclogo { 
+	margin-left: -100px;
+    padding-top: 15px;
+    text-align: center;
 }
 
 #foot h4 {
@@ -596,20 +608,12 @@ img.alignright {
 #foot a:hover, #foot a:focus {
 	color: #003d79;
 	}
-.bc-service {
-	font-size: 12px;
-	padding-left: 38px;
-}
-#bclogo { 
-	margin-left: -100px;
-    padding-top: 15px;
-    text-align: center;}
 #foot .row2 {
 	margin-top: 70px;
     padding-bottom: 30px;
 }
 
-.span3 ul li, .bc-service {
+.span3 ul li, .bc-service, .vcard {
 	font-size: 16px;
 	margin-bottom: 8px;
 }
@@ -1162,8 +1166,18 @@ div.span6 a {
 	}
 	#hero-links { margin-top: 10px;}
 
-	#bclogo { 
+	#foot .span3{
 		margin-left: 0px;
+		/* Override bootstrap width */
+		width: 200px;
+	}
+
+	#foot .span3 #bclogo { 
+		margin-left: -20px;
+	}
+
+	#foot .bc-footer {
+		width: 140px;
 	}
 
 	/* Donate page styling for buttons */

--- a/style.css
+++ b/style.css
@@ -1132,7 +1132,34 @@ div.span6 a {
 
 /* Portrait tablet to landscape and desktop */
 @media (min-width: 768px) and (max-width: 979px) {
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
+	}
+
+	/* Footer styling */
+	#foot .span3{
+		margin-left: 0px;
+		/* Override bootstrap width */
+		width: 200px;
+	}
+
+	#foot .span3 #bclogo { 
+		margin-left: -20px;
+	}
+
+	#foot .bc-footer {
+		width: 140px;
+	}
 	
+	/* Misc */
 	#main-nav.nav > li > a {
 	  font-size: 14px;
 	  line-height:22px;
@@ -1165,31 +1192,6 @@ div.span6 a {
 		margin-top: 5px;
 	}
 	#hero-links { margin-top: 10px;}
-
-	#foot .span3{
-		margin-left: 0px;
-		/* Override bootstrap width */
-		width: 200px;
-	}
-
-	#foot .span3 #bclogo { 
-		margin-left: -20px;
-	}
-
-	#foot .bc-footer {
-		width: 140px;
-	}
-
-	/* Donate page styling for buttons */
-	.donateButton a {
-		font-size: 24px;
-		border-radius: 14px;
-		
-	}
-
-	.donateButtonSpacer {
-		flex-basis: 0px!important;
-	}
 }
 
 /* Landscape phone to portrait tablet */

--- a/style.css
+++ b/style.css
@@ -580,7 +580,7 @@ img.alignright {
 
 #foot h4 {
  	font-family: 'PT Sans',"Helvetica Neue",Helvetica,Arial,sans-serif;
-	font-size: 16px;
+	font-size: 20px;
 	font-weight: bold;
 	color: #333;
 	}
@@ -607,6 +607,11 @@ img.alignright {
 #foot .row2 {
 	margin-top: 70px;
     padding-bottom: 30px;
+}
+
+.span3 ul li, .bc-service {
+	font-size: 16px;
+	margin-bottom: 8px;
 }
 	
 /*funddrive box*/

--- a/style.css
+++ b/style.css
@@ -617,6 +617,11 @@ img.alignright {
 	font-size: 16px;
 	margin-bottom: 8px;
 }
+
+p.street-address {
+	line-height: 1em;
+	margin-top: 8px;
+}
 	
 /*funddrive box*/
 .funddrive-alert {

--- a/style.css
+++ b/style.css
@@ -1068,6 +1068,12 @@ div.span6 a {
     word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
+/* Donate Page */
+.donateButton a {
+	font-size: 20px;
+	border-radius: 14px;
+}
+
 /* Large desktop overides */
 @media (min-width: 1200px) {
 	.blog h2, .home h2 {
@@ -1105,6 +1111,12 @@ div.span6 a {
 
 	#error404-goodnews h1 {
 		padding-top: 90px;
+	}
+
+	/* Donate Page, styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
 	}
 	
 }
@@ -1147,6 +1159,17 @@ div.span6 a {
 
 	#bclogo { 
 		margin-left: 0px;
+	}
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
 	}
 }
 
@@ -1297,6 +1320,17 @@ div.span6 a {
 	
 	#bclogo { 
 		margin-left: 0px;
+	}
+
+	/* Donate page styling for buttons */
+	.donateButton a {
+		font-size: 24px;
+		border-radius: 14px;
+		
+	}
+
+	.donateButtonSpacer {
+		flex-basis: 0px!important;
 	}
 
 }

--- a/template-car-donation.php
+++ b/template-car-donation.php
@@ -10,7 +10,7 @@ get_header(); ?>
 <div class="whatpageisthis">template-car-donation.php</div>
 
 <div class="row">
-	<div class="span8" id="content">
+	<main class="span8" id="content">
 		<?php while ( have_posts() ) : the_post(); ?>
 		
 			<h1><?php the_title();?></h1>
@@ -27,7 +27,7 @@ get_header(); ?>
 
 		endwhile; ?>
 
-	</div><!-- span8  #content -->
+	</main><!-- span8  #content -->
 
 	<?php get_sidebar(); // sidebar 1 ?>
 

--- a/template-nav-page.php
+++ b/template-nav-page.php
@@ -10,7 +10,7 @@
 <div class="whatpageisthis">template-nav-page.php</div>
 
 <div class="row">
-	<div class="span8" id="content">
+	<main class="span8" id="content">
 		<?php while ( have_posts() ) : the_post(); ?>
 		
         	<h1><?php the_title();?></h1>
@@ -61,7 +61,7 @@
 		?>
 
         
-    </div><!-- span8  #content -->
+    </main><!-- span8  #content -->
     
 	<?php get_sidebar(); // sidebar 1 ?>
 

--- a/template-programs.php
+++ b/template-programs.php
@@ -13,7 +13,7 @@ $archivedprograms = array();  //create list of programs (and maybe segments) tha
 
 	<div class="container">
 		<div class="row">	
-			<div class="span8" id="content">
+			<main class="span8" id="content">
 		
 		
 				<h1>Programs</h1>
@@ -582,7 +582,7 @@ $archivedprograms = array();  //create list of programs (and maybe segments) tha
 						
 						</script>
 						
-					</div><!--#content .span8 -->
+					</main><!--#content .span8 -->
 				<?php get_sidebar(); ?>
 				</div><!-- row -->
 			</div><!-- container -->

--- a/template-staff-directory.php
+++ b/template-staff-directory.php
@@ -9,7 +9,7 @@ get_header(); ?>
 	
 			<div class="container">
 				<div class="row">	
-					<div class="span8" id="content">
+					<main class="span8" id="content">
 							<h1>Staff</h1>
 								
 							    <ul class="nav nav-tabs" id="myTab">
@@ -302,7 +302,7 @@ get_header(); ?>
 							});						
 						</script>			
 		    
-					</div><!-- #content .span8 -->
+					</main><!-- #content .span8 -->
 				<?php get_sidebar(); ?>
 				</div><!-- row -->
 			</div><!-- container -->


### PR DESCRIPTION
### `catlist` template was improperly configured `single-blog.php`

- Requires that template be in a folder called `list-category-posts`
- Template was using non-standard methods for grabbing posts.
- Template did not properly filter by category `news-and-ideas`

### Additional Changes

- Found that the single-blog templates rely on `format-standard.php` and `format-video.php`
- Changed these formatting templates to wrap in an `<article>` HTML5 tag for readability and accessibility
- Changed content flow means that some bootstrap styles had to be over-ridden in `styles.css`

### Results

- The news page no longer renders as a `<ul>` with `<divs>` inside of `<li>`'s
- Both the news and main page now can be read by accessibility tools to understand there are articles present.
- These changes do not require any technical expertise from KBCS staff and will work with the existing `catlist` block on the site.