### PR TITLE
Small changes requested by staff

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -162,6 +162,26 @@ function be_hidden_meta_boxes($hidden, $screen) {
 			add_theme_support('menus');
 		}
 
+	// RSS Feed support for using thumbnails:
+	// From https://wordpress.stackexchange.com/questions/59492/how-to-add-post-featured-image-to-rss-item-tag
+		function dn_add_rss_image() {
+			global $post;
+	
+			$output = '';
+			if ( has_post_thumbnail( $post->ID ) ) {
+				$thumbnail_ID = get_post_thumbnail_id( $post->ID );
+				$thumbnail = wp_get_attachment_image_src( $thumbnail_ID, 'thumbnail' );
+	
+				$output .= '<media:content xmlns:media="http://search.yahoo.com/mrss/" medium="image" type="image/jpeg"';
+				$output .= ' url="'. $thumbnail[0] .'"';
+				$output .= ' width="'. $thumbnail[1] .'"';
+				$output .= ' height="'. $thumbnail[2] .'"';
+				$output .= ' />';
+			}
+			echo $output;
+		}
+		add_action( 'rss2_item', 'dn_add_rss_image' );
+
 register_nav_menus( array(
 	'main-nav' => __( 'Main Nav' ),
 	'sub-nav' => __( 'Sub Nav' )

--- a/single-programs.php
+++ b/single-programs.php
@@ -64,7 +64,7 @@ $audio_content = json_encode($output);
 <div class="container">
 		<div class="row">
 			<main class="span8" id="content">
-			<div id="hero-block">
+			<div class='programs-hero' id="hero-block">
 
 				<div class="row-fluid"  id="hero-text-wrapper">
 					 <div class="span9" id="hero-text">
@@ -95,9 +95,16 @@ $audio_content = json_encode($output);
 						}
 						?>
 						
-						<p class="program-days-times">
-							<?php echo Homepage_Program::get_airtimes_for_display( $post->ID ); ?>
-						</p>
+							<div class="program-days-times">
+								<?php 
+								$airtimes = Homepage_Program::get_airtimes_for_display($post->ID);
+								// Split on commas that are followed by a day of the week
+								$times = preg_split('/(?<=(?:am|pm)),\s*(?=[A-Za-z]+day)/', $airtimes);
+								foreach ($times as $time) {
+									echo '<p>' . trim($time) . '</p>';
+								}
+								?>
+							</div>
 						</div><!-- .inner -->
 					</div> <!-- hero-text -->
 

--- a/style.css
+++ b/style.css
@@ -216,10 +216,14 @@ h5 {
 }
 
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
- 	color: #603312;	
+ 	color: #603312;
 }
 
-h2 a { 
+.media-body a:has(h2.media-heading) {
+    text-decoration: none;
+}
+
+h2 a{ 
 	text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -1143,6 +1143,16 @@ text-align: center;
 	margin-top: 0;
 	font-weight: bold;
 }
+
+/* Reflowed single program hero */
+#hero-block.programs-hero #hero-text-wrapper.row-fluid h1 {
+	margin-left: 0;
+	margin-bottom: 0.25rem;
+}
+
+#hero-block.programs-hero #hero-text-wrapper.row-fluid p {
+	margin-bottom: 0.5rem;
+}
 	
 /* Post formats */
 
@@ -1354,6 +1364,10 @@ div.span6 a {
 	#hero-text p {
 		font-size: 1.0625em;
 		line-height: 1.875em;
+	}
+
+	#hero-block.programs-hero #hero-text-wrapper.row-fluid h1 {
+		line-height: normal;
 	}
 
 	#error404-goodnews h1 {

--- a/template-staff-directory.php
+++ b/template-staff-directory.php
@@ -57,7 +57,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+				    							<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 												<?php
 													if(get_post_meta($post->ID, 'staff_role', true !='')) {
@@ -129,7 +129,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+											<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 
 												<?php
@@ -217,7 +217,7 @@ get_header(); ?>
 									    	
 									    	<div class="media-body">
 			
-				    							<a href="<?php the_permalink(); ?>"><h2 class="media-heading"><?php the_title(); ?></h2></a>
+												<h2 class="media-heading"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 
 												<?php
 													if(get_post_meta($post->ID, 'staff_role', true !='')) {


### PR DESCRIPTION
### Mostly UI Fixes

- Each pull request I made into my trunk documents the design fixes made.
- The commit on April 2nd to styles.css may no longer be needed since I fixed a structure issue in staff-page-template.php today
- See individual commits for more detailed docs

### Noteworthy changes

- Single pages for shows now include new lines for each show time(s), so that the view is not cluttered for KBCS Jukebox
- Functions.php now includes code that I found on a stackexchange that I was able to test for inserting the featured image into the RSS feed as a preview, this resolves a request from Greg so that people do not need to embed images in their blog posts unless they are different from the featured image

If everything looks good, lets stage this theme update @taija 